### PR TITLE
Add GitHub Copilot API support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 # Only one token is required. If both are set, OpenAI will be used.
 VITE_OPENAI_TOKEN=
 VITE_DEEPSEEK_TOKEN=
+VITE_GITHUB_COPILOT_TOKEN=

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Projeto de um micro SAAS para criação de currículo
 
 ## Ambiente
 
-Crie um arquivo `.env` na raiz do projeto a partir do arquivo `.env.example` e defina o token para a API que deseja utilizar. É possível informar um token da OpenAI (`VITE_OPENAI_TOKEN`) ou da DeepSeek (`VITE_DEEPSEEK_TOKEN`). Caso ambos estejam presentes, a aplicação dará preferência ao token da OpenAI:
+Crie um arquivo `.env` na raiz do projeto a partir do arquivo `.env.example` e defina o token para a API que deseja utilizar. É possível informar um token da OpenAI (`VITE_OPENAI_TOKEN`), da DeepSeek (`VITE_DEEPSEEK_TOKEN`) ou do GitHub Copilot (`VITE_GITHUB_COPILOT_TOKEN`). Caso mais de um esteja presente, a aplicação dará preferência ao token da OpenAI e, em seguida, ao da DeepSeek:
 
 ```bash
 cp .env.example .env
@@ -15,6 +15,7 @@ Exemplo de `.env`:
 ```
 VITE_OPENAI_TOKEN=seu_token_opcional
 VITE_DEEPSEEK_TOKEN=seu_token_opcional
+VITE_GITHUB_COPILOT_TOKEN=seu_token_opcional
 ```
 
-Durante o build, o token será acessado através das variáveis `VITE_OPENAI_TOKEN` ou `VITE_DEEPSEEK_TOKEN`.
+Durante o build, o token será acessado através das variáveis `VITE_OPENAI_TOKEN`, `VITE_DEEPSEEK_TOKEN` ou `VITE_GITHUB_COPILOT_TOKEN`.

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -23,9 +23,12 @@ function HomePage() {
   const [isLoading, setIsLoading] = useState(false);
   const openAiKey = import.meta.env.VITE_OPENAI_TOKEN;
   const deepSeekKey = import.meta.env.VITE_DEEPSEEK_TOKEN;
+  const copilotKey = import.meta.env.VITE_GITHUB_COPILOT_TOKEN;
 
-  const apiKey = openAiKey || deepSeekKey;
+  const apiKey = openAiKey || deepSeekKey || copilotKey;
   const isOpenAI = Boolean(openAiKey);
+  const isDeepSeek = !isOpenAI && Boolean(deepSeekKey);
+  const isCopilot = !isOpenAI && !isDeepSeek && Boolean(copilotKey);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -48,16 +51,18 @@ O currículo deve incluir as seguintes seções:
     try {
       const endpoint = isOpenAI
         ? 'https://api.openai.com/v1/chat/completions'
-        : 'https://api.deepseek.com/v1/chat/completions';
+        : isDeepSeek
+          ? 'https://api.deepseek.com/v1/chat/completions'
+          : 'https://api.github.com/copilot/v1/chat/completions';
 
       const response = await fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${apiKey}`
+          'Authorization': isCopilot ? `token ${apiKey}` : `Bearer ${apiKey}`
         },
         body: JSON.stringify({
-          model: isOpenAI ? 'gpt-3.5-turbo' : 'deepseek-chat',
+          model: isOpenAI ? 'gpt-3.5-turbo' : isDeepSeek ? 'deepseek-chat' : 'github-copilot-chat',
           messages: [{ role: 'user', content: prompt }],
           temperature: 0.7,
         })


### PR DESCRIPTION
## Summary
- add environment variable `VITE_GITHUB_COPILOT_TOKEN`
- document new GitHub Copilot token in README
- support Copilot as fallback chat API in `HomePage`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68646844b7f883288684abfc43eb08e9

## Resumo por Sourcery

Adiciona suporte para a API do GitHub Copilot como um fallback opcional de backend de chat e documenta sua configuração.

Novas Funcionalidades:
- Introduz a variável de ambiente `VITE_GITHUB_COPILOT_TOKEN` para acesso à API do Copilot.
- Estende a seleção de provedores de chat para incluir o GitHub Copilot quando os tokens OpenAI e DeepSeek não são fornecidos.
- Configura endpoint específico do Copilot, header de autenticação e identificador de modelo no componente `HomePage`.

Documentação:
- Atualiza o `README` e o `.env.example` para descrever como configurar e usar o token do GitHub Copilot.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for GitHub Copilot API as an optional chat backend fallback and document its configuration.

New Features:
- Introduce VITE_GITHUB_COPILOT_TOKEN environment variable for Copilot API access.
- Extend chat provider selection to include GitHub Copilot when OpenAI and DeepSeek tokens are not provided.
- Configure Copilot-specific endpoint, authentication header, and model identifier in HomePage component.

Documentation:
- Update README and .env.example to describe how to configure and use the GitHub Copilot token.

</details>