### PR TITLE
Corrige margem do PDF para iniciar no topo

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -89,7 +89,7 @@ body {
     top: 0;
     width: 100%;
     margin: 0;
-    padding: 20px;
+    padding: 0 20px;
     border: none;
     box-shadow: none;
     background: white !important;
@@ -120,6 +120,6 @@ body {
 
   @page {
     size: A4;
-    margin: 20mm;
+    margin: 10mm;
   }
 }


### PR DESCRIPTION
## Summary
- remove padding top and reduce page margin so resume printing starts at the top

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68647d972c9c83288997757a359f6160

## Resumo por Sourcery

Ajusta o layout de impressão em PDF para iniciar o conteúdo no topo, removendo o preenchimento extra e reduzindo as margens da página.

Melhorias:
- Remove o preenchimento superior do corpo e adiciona apenas preenchimento horizontal para o layout em PDF
- Reduz a margem da página A4 de 20mm para 10mm para uma impressão mais compacta

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust PDF print layout to start content at the top by removing extra padding and reducing page margins.

Enhancements:
- Remove top padding from the body and add only horizontal padding for PDF layout
- Reduce A4 page margin from 20mm to 10mm for more compact printing

</details>