### PR TITLE
Add email and phone fields to resume generator

### DIFF
--- a/src/components/ResumePreview.jsx
+++ b/src/components/ResumePreview.jsx
@@ -49,13 +49,20 @@ const parseMarkdownToJsx = (markdown) => {
 export function ResumePreview({ data }) {
   if (!data) return null;
 
-  const { nomeCompleto, cargoDesejado, generatedContent } = data;
+  const { nomeCompleto, cargoDesejado, email, telefone, generatedContent } = data;
 
   return (
     <div id="resume-to-print" className="bg-white/5 rounded-lg p-8 text-left mt-8">
       <div className="text-center mb-8">
         <h1 className="text-4xl font-bold text-white">{nomeCompleto}</h1>
         <h2 className="text-2xl text-blue-300">{cargoDesejado}</h2>
+        {(email || telefone) && (
+          <p className="text-gray-300 mt-2">
+            {email && <span>{email}</span>}
+            {email && telefone && ' | '}
+            {telefone && <span>{telefone}</span>}
+          </p>
+        )}
       </div>
       <div className="prose prose-invert max-w-none">
         {parseMarkdownToJsx(generatedContent)}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -17,6 +17,8 @@ function HomePage() {
   const [formData, setFormData] = useState({
     nomeCompleto: '',
     cargoDesejado: '',
+    email: '',
+    telefone: '',
     tecnologias: [],
     experiencias: ''
   });
@@ -40,6 +42,8 @@ function HomePage() {
 
 **Nome:** ${formData.nomeCompleto}
 **Cargo Desejado:** ${formData.cargoDesejado}
+**Email:** ${formData.email}
+**Telefone:** ${formData.telefone}
 **Tecnologias:** ${formData.tecnologias.join(', ')}
 **Experiência:** ${formData.experiencias}
 
@@ -201,6 +205,36 @@ O currículo deve incluir as seguintes seções:
                     placeholder="Ex: Desenvolvedor Full Stack"
                     value={formData.cargoDesejado}
                     onChange={(e) => setFormData(prev => ({ ...prev, cargoDesejado: e.target.value }))}
+                    className="bg-white/5 border-white/20 text-white placeholder-white/60"
+                    required
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="email" className="text-white font-medium">
+                    Email *
+                  </Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="seu@email.com"
+                    value={formData.email}
+                    onChange={(e) => setFormData(prev => ({ ...prev, email: e.target.value }))}
+                    className="bg-white/5 border-white/20 text-white placeholder-white/60"
+                    required
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="telefone" className="text-white font-medium">
+                    Telefone de Contato *
+                  </Label>
+                  <Input
+                    id="telefone"
+                    type="tel"
+                    placeholder="(11) 99999-9999"
+                    value={formData.telefone}
+                    onChange={(e) => setFormData(prev => ({ ...prev, telefone: e.target.value }))}
                     className="bg-white/5 border-white/20 text-white placeholder-white/60"
                     required
                   />


### PR DESCRIPTION
## Summary
- collect email and phone in home page form
- include new contact data in AI prompt
- display email and phone on generated resume preview

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68648230fd9083288566ab21c3f9bc5c