### PR TITLE
Add cookie consent banner and clear resume data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { Toaster } from '@/components/ui/toaster';
 import HomePage from '@/pages/HomePage';
 import ResultPage from '@/pages/ResultPage';
+import CookieBanner from '@/components/CookieBanner';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
           <Route path="/curriculo-gerado" element={<ResultPage />} />
         </Routes>
         <Toaster />
+        <CookieBanner />
       </div>
     </Router>
   );

--- a/src/components/CookieBanner.jsx
+++ b/src/components/CookieBanner.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consentGiven = localStorage.getItem('cookieConsent');
+    if (!consentGiven) {
+      setVisible(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem('cookieConsent', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 bg-slate-800/90 backdrop-blur-sm p-4 border-t border-white/10">
+      <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+        <p className="text-sm text-gray-200">
+          Usamos cookies essenciais para o funcionamento do site. Nenhum dado informado 
+          é armazenado e todas as informações são excluídas após a geração do currículo.
+        </p>
+        <Button onClick={acceptCookies} size="sm">
+          Aceitar
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default CookieBanner;

--- a/src/pages/ResultPage.jsx
+++ b/src/pages/ResultPage.jsx
@@ -20,6 +20,7 @@ function ResultPage() {
       return;
     }
     setCurriculoData(JSON.parse(data));
+    localStorage.removeItem('curriculoData');
   }, [navigate]);
 
   const handleDownload = () => {


### PR DESCRIPTION
## Summary
- show a cookie banner on first visit
- delete resume data once the result page loads

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68655bc1d440832893116cbc548101ac