### PR TITLE
Add generic message for AI credit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,65 @@
 # microsaas-curriculo
-Projeto de um micro SAAS para criação de currículo
 
-## Ambiente
+Aplicação web para gerar currículos profissionais usando IA. Foi criada como um micro SAAS utilizando React e Vite com Tailwind CSS.
 
-Crie um arquivo `.env` na raiz do projeto a partir do arquivo `.env.example` e defina o token para a API que deseja utilizar. É possível informar um token da OpenAI (`VITE_OPENAI_TOKEN`), da DeepSeek (`VITE_DEEPSEEK_TOKEN`) ou do GitHub Copilot (`VITE_GITHUB_COPILOT_TOKEN`). Caso mais de um esteja presente, a aplicação dará preferência ao token da OpenAI e, em seguida, ao da DeepSeek:
+## Requisitos
+
+- Node.js 18 ou superior
+- npm 9 ou superior
+
+## Instalação
+
+Clone o repositório e instale as dependências:
+
+```bash
+npm install
+```
+
+## Configuração do `.env`
+
+Copie o arquivo `.env.example` para `.env` e informe o token da API que deseja usar. A aplicação suporta tokens da OpenAI (`VITE_OPENAI_TOKEN`), DeepSeek (`VITE_DEEPSEEK_TOKEN`) e GitHub Copilot (`VITE_GITHUB_COPILOT_TOKEN`). Caso mais de um token seja definido, o da OpenAI será priorizado, seguido pelo da DeepSeek.
 
 ```bash
 cp .env.example .env
-# edite .env e adicione o token
+# edite .env e adicione seu token
 ```
 
-Exemplo de `.env`:
+Exemplo de conteúdo:
 
-```
+```env
 VITE_OPENAI_TOKEN=seu_token_opcional
 VITE_DEEPSEEK_TOKEN=seu_token_opcional
 VITE_GITHUB_COPILOT_TOKEN=seu_token_opcional
 ```
 
-Durante o build, o token será acessado através das variáveis `VITE_OPENAI_TOKEN`, `VITE_DEEPSEEK_TOKEN` ou `VITE_GITHUB_COPILOT_TOKEN`.
+## Executando em modo de desenvolvimento
+
+Inicie o servidor de desenvolvimento com:
+
+```bash
+npm run dev
+```
+
+A aplicação ficará disponível em `http://localhost:5173` por padrão.
+
+## Build de produção
+
+Para gerar a versão otimizada execute:
+
+```bash
+npm run build
+```
+
+Os arquivos prontos serão criados na pasta `dist`.
+
+## Política de Cookies
+
+Ao acessar o site pela primeira vez, é exibido um banner informando que apenas cookies essenciais são utilizados. Nenhum dado fornecido é armazenado permanentemente. Os dados do currículo são guardados temporariamente no `localStorage` e removidos automaticamente assim que a página de resultados é carregada.
+
+## Como usar
+
+1. Preencha o formulário inicial com suas informações profissionais.
+2. Clique em gerar e aguarde a criação do currículo.
+3. Após visualizar o currículo, você pode fazer o download em PDF ou iniciar um novo.
+
+Todo conteúdo informado é descartado após a geração, garantindo privacidade total.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { Toaster } from '@/components/ui/toaster';
 import HomePage from '@/pages/HomePage';
 import ResultPage from '@/pages/ResultPage';
+import CookieBanner from '@/components/CookieBanner';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
           <Route path="/curriculo-gerado" element={<ResultPage />} />
         </Routes>
         <Toaster />
+        <CookieBanner />
       </div>
     </Router>
   );

--- a/src/components/CookieBanner.jsx
+++ b/src/components/CookieBanner.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consentGiven = localStorage.getItem('cookieConsent');
+    if (!consentGiven) {
+      setVisible(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem('cookieConsent', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 bg-slate-800/90 backdrop-blur-sm p-4 border-t border-white/10">
+      <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+        <p className="text-sm text-gray-200">
+          Usamos cookies essenciais para o funcionamento do site. Nenhum dado informado 
+          é armazenado e todas as informações são excluídas após a geração do currículo.
+        </p>
+        <Button onClick={acceptCookies} size="sm">
+          Aceitar
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default CookieBanner;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -96,9 +96,14 @@ O currículo deve incluir as seguintes seções:
       navigate('/curriculo-gerado');
     } catch (error) {
       console.error(error);
+      const creditError = /quota|credit|crédit|cred[ií]tos|billing|payment/i.test(
+        error.message
+      );
       toast({
         title: "Erro",
-        description: `Ocorreu um erro ao gerar o currículo: ${error.message}`,
+        description: creditError
+          ? "O sistema não está respondendo. Tente novamente mais tarde."
+          : `Ocorreu um erro ao gerar o currículo: ${error.message}`,
         variant: "destructive"
       });
     } finally {

--- a/src/pages/ResultPage.jsx
+++ b/src/pages/ResultPage.jsx
@@ -20,6 +20,7 @@ function ResultPage() {
       return;
     }
     setCurriculoData(JSON.parse(data));
+    localStorage.removeItem('curriculoData');
   }, [navigate]);
 
   const handleDownload = () => {


### PR DESCRIPTION
## Summary
- show cookie info when the page first loads so visitors know the data policy
- clean up localStorage after the CV preview is shown
- display a generic error when API credits are exhausted

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68655bc1d440832893116cbc548101ac

## Resumo por Sourcery

Adiciona um banner de consentimento de cookies, limpa os dados do currículo após a visualização, mostra um erro genérico para créditos de API esgotados e expande a documentação do projeto com detalhes de configuração e política

Novas funcionalidades:
- Introduz um banner de consentimento de cookies que aparece na primeira visita e armazena o consentimento no localStorage

Melhorias:
- Limpa os dados do currículo armazenados no localStorage quando a página de resultados é carregada
- Exibe uma mensagem de erro genérica quando os créditos da API são esgotados

Documentação:
- Reformula o README com etapas de instalação detalhadas, guia de configuração, comandos de desenvolvimento e produção, política de cookies e instruções de uso

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a cookie consent banner, clear curriculum data after preview, show generic error for exhausted API credits, and expand project documentation with setup and policy details

New Features:
- Introduce a cookie consent banner that appears on first visit and stores consent in localStorage

Enhancements:
- Clear stored resume data from localStorage when the result page loads
- Display a generic fallback error message when API credits are exhausted

Documentation:
- Overhaul README with detailed installation steps, configuration guide, development and production commands, cookie policy, and usage instructions

</details>