### PR TITLE
Integrate AdSense banner code

### DIFF
--- a/src/components/AdBanner.jsx
+++ b/src/components/AdBanner.jsx
@@ -1,25 +1,35 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { cn } from '@/lib/utils';
 
-export function AdBanner({ id, className, content }) {
+export function AdBanner({ id, className, content, slot }) {
+  useEffect(() => {
+    if (import.meta.env.DEV) return;
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (e) {
+      console.error(e);
+    }
+  }, []);
+
   return (
-    <div className={cn("ad-banner", className)}>
-      <ins 
+    <div id={id} className={cn('ad-banner', className)}>
+      <ins
         className="adsbygoogle"
         style={{ display: 'block' }}
-        data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
-        data-ad-slot="xxxxxxxxxx"
+        data-ad-client="ca-pub-4789090074866563"
+        data-ad-slot={slot || 'xxxxxxxxxx'}
         data-ad-format="auto"
         data-full-width-responsive="true"
       ></ins>
-      
-      {/* Placeholder content for development */}
-      <div className="flex items-center justify-center h-full">
-        <span className="text-sm font-medium opacity-75">
-          {content}
-        </span>
-      </div>
+
+      {import.meta.env.DEV && (
+        <div className="flex items-center justify-center h-full">
+          <span className="text-sm font-medium opacity-75">
+            {content}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/ResultPage.jsx
+++ b/src/pages/ResultPage.jsx
@@ -57,9 +57,10 @@ function ResultPage() {
             transition={{ duration: 0.6 }}
             className="mb-8"
           >
-            <AdBanner 
+            <AdBanner
               id="header-banner"
               className="h-24"
+              slot="8561357541"
               content="🎯 Espaço para Banner AdSense - Cabeçalho da Página de Resultado"
             />
           </motion.div>


### PR DESCRIPTION
## Summary
- show actual AdSense banner code
- load banner in the result page header

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865d3b4ccac83288669aaca49b1fb32

## Resumo por Sourcery

Integra banners AdSense ao vivo em todo o aplicativo, substituindo a marcação de espaço reservado por slots de anúncios reais e carregando anúncios em produção.

Novos recursos:
- Carrega anúncios AdSense reais em produção por meio de uma chamada `window.adsbygoogle.push` no componente AdBanner.
- Expõe uma prop `slot` no AdBanner para configurar o ID do slot AdSense dinamicamente.

Melhorias:
- Envolve o conteúdo do espaço reservado em uma proteção somente para desenvolvimento para evitar mostrá-lo em produção.
- Incorpora o AdBanner no cabeçalho da página de resultados com um ID de slot específico para entrega de anúncios reais.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate live AdSense banners across the app by replacing placeholder markup with real ad slots and loading ads in production.

New Features:
- Load actual AdSense ads in production via a `window.adsbygoogle.push` call in the AdBanner component.
- Expose a `slot` prop on AdBanner to configure the AdSense slot ID dynamically.

Enhancements:
- Wrap placeholder content in a development-only guard to avoid showing it in production.
- Embed the AdBanner in the result page header with a specific slot ID for real ad delivery.

</details>