### PR TITLE
Add policy pages and ads.txt for AdSense compliance

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="generator" content="Hostinger Horizons" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Crie currículos profissionais usando inteligência artificial de forma rápida e segura." />
     <title>Gerador de Currículos com IA</title>
   </head>
   <body>

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4789090074866563, DIRECT, f08c47fec0942fa0

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,5 @@
+## Pages
+- [Currículo Gerado com Sucesso - Download Disponível](/curriculo-gerado): Seu currículo profissional foi gerado com sucesso. Faça o download agora mesmo!
+- [Gerador de Currículos com IA - Crie seu CV Profissional](/): Gere currículos profissionais para área de tecnologia usando inteligência artificial. Rápido, fácil e moderno.
+- [Política de Privacidade](/politica-de-privacidade): Saiba como tratamos seus dados no gerador de currículos.
+- [Termos de Uso](/termos-de-uso): Conheça os termos de uso do gerador de currículos.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,10 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { Toaster } from '@/components/ui/toaster';
 import HomePage from '@/pages/HomePage';
 import ResultPage from '@/pages/ResultPage';
+import PrivacyPolicy from '@/pages/PrivacyPolicy';
+import TermsOfService from '@/pages/TermsOfService';
 import CookieBanner from '@/components/CookieBanner';
+import Footer from '@/components/Footer';
 
 function App() {
   return (
@@ -13,7 +16,10 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/curriculo-gerado" element={<ResultPage />} />
+          <Route path="/politica-de-privacidade" element={<PrivacyPolicy />} />
+          <Route path="/termos-de-uso" element={<TermsOfService />} />
         </Routes>
+        <Footer />
         <Toaster />
         <CookieBanner />
       </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function Footer() {
+  return (
+    <footer className="text-center py-4 border-t border-white/10 bg-slate-900/95 backdrop-blur-sm">
+      <div className="max-w-4xl mx-auto text-gray-400 text-sm flex flex-col sm:flex-row gap-2 justify-center">
+        <Link to="/politica-de-privacidade" className="hover:text-white">Política de Privacidade</Link>
+        <span className="hidden sm:block">|</span>
+        <Link to="/termos-de-uso" className="hover:text-white">Termos de Uso</Link>
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+
+function PrivacyPolicy() {
+  const navigate = useNavigate();
+  return (
+    <div className="min-h-screen py-8 px-4 max-w-3xl mx-auto">
+      <Helmet>
+        <title>Política de Privacidade</title>
+        <meta name="description" content="Saiba como tratamos seus dados no gerador de currículos." />
+      </Helmet>
+      <h1 className="text-3xl font-bold mb-4 text-white">Política de Privacidade</h1>
+      <p className="mb-4 text-gray-300">
+        Este site utiliza apenas cookies essenciais para seu funcionamento. Nenhuma informação pessoal é armazenada em nossos servidores. Os dados informados são usados somente para gerar seu currículo e são excluídos após o processamento.
+      </p>
+      <p className="mb-4 text-gray-300">
+        Ao prosseguir utilizando o gerador de currículos, você concorda com esta política de privacidade.
+      </p>
+      <Button onClick={() => navigate('/')} variant="outline" className="border-white/20 text-white hover:bg-white/10">
+        Voltar para a página inicial
+      </Button>
+    </div>
+  );
+}
+
+export default PrivacyPolicy;

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+
+function TermsOfService() {
+  const navigate = useNavigate();
+  return (
+    <div className="min-h-screen py-8 px-4 max-w-3xl mx-auto">
+      <Helmet>
+        <title>Termos de Uso</title>
+        <meta name="description" content="Conheça os termos de uso do gerador de currículos." />
+      </Helmet>
+      <h1 className="text-3xl font-bold mb-4 text-white">Termos de Uso</h1>
+      <p className="mb-4 text-gray-300">
+        Este serviço é fornecido "como está" sem garantias de qualquer tipo. Não armazenamos permanentemente suas informações e o conteúdo gerado é de sua responsabilidade.
+      </p>
+      <p className="mb-4 text-gray-300">
+        Ao utilizar o gerador de currículos você concorda em usar as informações geradas de forma ética e legal.
+      </p>
+      <Button onClick={() => navigate('/')} variant="outline" className="border-white/20 text-white hover:bg-white/10">
+        Voltar para a página inicial
+      </Button>
+    </div>
+  );
+}
+
+export default TermsOfService;


### PR DESCRIPTION
## Summary
- add meta description to `index.html`
- create `PrivacyPolicy` and `TermsOfService` pages
- add `Footer` with links to policy pages
- add `ads.txt` for AdSense
- register new pages in the router

## Testing
- `npm install`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_6866ab8e46548328af05f8cc3254b307