### PR TITLE
Reduce Ad banner heights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gerador-curriculos-ia",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gerador-curriculos-ia",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-avatar": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gerador-curriculos-ia",
   "type": "module",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -173,9 +173,9 @@ O currículo deve incluir as seguintes seções:
             transition={{ duration: 0.6 }}
             className="mb-8"
           >
-            <AdBanner 
+            <AdBanner
               id="top-banner"
-              className="h-24"
+              className="h-16"
               content="🚀 Espaço para Banner AdSense - Topo da Página"
             />
           </motion.div>

--- a/src/pages/ResultPage.jsx
+++ b/src/pages/ResultPage.jsx
@@ -59,7 +59,7 @@ function ResultPage() {
           >
             <AdBanner
               id="header-banner"
-              className="h-24"
+              className="h-16"
               slot="8561357541"
               content="🎯 Espaço para Banner AdSense - Cabeçalho da Página de Resultado"
             />
@@ -199,9 +199,9 @@ function ResultPage() {
           className="fixed bottom-0 left-0 right-0 p-4 bg-slate-900/95 backdrop-blur-sm border-t border-white/10"
         >
           <div className="max-w-4xl mx-auto">
-            <AdBanner 
+            <AdBanner
               id="footer-banner"
-              className="h-16"
+              className="h-12"
               content="🚀 Espaço para Banner AdSense - Rodapé Fixo"
             />
           </div>


### PR DESCRIPTION
## Summary
- shrink top banner on HomePage
- shrink header banner on ResultPage
- shrink footer banner on ResultPage
- bump version to 0.0.1

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867133533a88328ac5dc838c8fe9a81

## Resumo por Sourcery

Reduz as alturas exibidas dos componentes AdBanner em HomePage e ResultPage e atualiza a versão do pacote.

Melhorias:
- Diminui o AdBanner superior em HomePage de h-24 para h-16
- Reduz a altura do AdBanner do cabeçalho em ResultPage de h-24 para h-16
- Diminui a altura do AdBanner do rodapé em ResultPage de h-16 para h-12

Build:
- Aumenta a versão do projeto para 0.0.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reduce the displayed heights of AdBanner components on HomePage and ResultPage and update the package version.

Enhancements:
- Shrink the top AdBanner on HomePage from h-24 to h-16
- Reduce the header AdBanner height on ResultPage from h-24 to h-16
- Decrease the footer AdBanner height on ResultPage from h-16 to h-12

Build:
- Bump project version to 0.0.1

</details>