### PR TITLE
Add Dockerfile for Vite build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Stage 1: build the application
+FROM node:20-alpine AS build
+
+# set working directory
+WORKDIR /app
+
+# install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# copy source
+COPY . .
+
+# build for production
+RUN npm run build
+
+# Stage 2: serve with nginx
+FROM nginx:alpine
+
+# copy built files
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# expose port 80
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add Dockerfile to build the Vite app with Node and serve using nginx

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868830369cc832884d54bfaa27ba003

## Resumo por Sourcery

Adiciona um Dockerfile multi-estágio que constrói o aplicativo Vite em um ambiente Node e serve os assets estáticos resultantes com nginx

Novas Funcionalidades:
- Adiciona um Dockerfile multi-estágio para conteinerizar a aplicação Vite

Implantação:
- Serve a build de produção usando nginx em um container leve

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a multi-stage Dockerfile that builds the Vite app in a Node environment and serves the resulting static assets with nginx

New Features:
- Add a multi-stage Dockerfile to containerize the Vite application

Deployment:
- Serve the production build using nginx in a lightweight container

</details>