### PR TITLE
Add AdSense meta tag on all pages

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -163,6 +163,7 @@ O currículo deve incluir as seguintes seções:
       <Helmet>
         <title>Gerador de Currículos com IA - Crie seu CV Profissional</title>
         <meta name="description" content="Gere currículos profissionais para área de tecnologia usando inteligência artificial. Rápido, fácil e moderno." />
+        <meta name="google-adsense-account" content="ca-pub-4789090074866563" />
       </Helmet>
 
       <div className="min-h-screen py-8 px-4">

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -10,6 +10,7 @@ function PrivacyPolicy() {
       <Helmet>
         <title>Política de Privacidade</title>
         <meta name="description" content="Saiba como tratamos seus dados no gerador de currículos." />
+        <meta name="google-adsense-account" content="ca-pub-4789090074866563" />
       </Helmet>
       <h1 className="text-3xl font-bold mb-4 text-white">Política de Privacidade</h1>
       <p className="mb-4 text-gray-300">

--- a/src/pages/ResultPage.jsx
+++ b/src/pages/ResultPage.jsx
@@ -47,6 +47,7 @@ function ResultPage() {
       <Helmet>
         <title>Currículo Gerado com Sucesso - Download Disponível</title>
         <meta name="description" content="Seu currículo profissional foi gerado com sucesso. Faça o download agora mesmo!" />
+        <meta name="google-adsense-account" content="ca-pub-4789090074866563" />
       </Helmet>
 
       <div className="min-h-screen py-8 px-4">

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -10,6 +10,7 @@ function TermsOfService() {
       <Helmet>
         <title>Termos de Uso</title>
         <meta name="description" content="Conheça os termos de uso do gerador de currículos." />
+        <meta name="google-adsense-account" content="ca-pub-4789090074866563" />
       </Helmet>
       <h1 className="text-3xl font-bold mb-4 text-white">Termos de Uso</h1>
       <p className="mb-4 text-gray-300">


### PR DESCRIPTION
## Summary
- add Google AdSense meta tag within each React page's head section

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68693d22a2d48328bcf26211613dcd14

## Resumo por Sourcery

Melhorias:
- Inclui a meta tag da conta do Google AdSense no cabeçalho de HomePage, PrivacyPolicy, ResultPage e TermsOfService

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Include Google AdSense account meta tag in the head of HomePage, PrivacyPolicy, ResultPage, and TermsOfService

</details>