### PR TITLE
Add footer with privacy and terms links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,9 +6,12 @@ import ResultPage from '@/pages/ResultPage';
 import LoginPage from '@/pages/LoginPage';
 import RegisterPage from '@/pages/RegisterPage';
 import PricingPage from '@/pages/PricingPage';
+import PrivacyPolicy from '@/pages/PrivacyPolicy';
+import TermsOfService from '@/pages/TermsOfService';
 import { AuthProvider } from '@/contexts/SupabaseAuthContext';
 import Header from '@/components/Header';
 import CookieBanner from '@/components/CookieBanner';
+import Footer from '@/components/Footer';
 
 function App() {
   return (
@@ -23,8 +26,11 @@ function App() {
               <Route path="/login" element={<LoginPage />} />
               <Route path="/cadastro" element={<RegisterPage />} />
               <Route path="/planos" element={<PricingPage />} />
+              <Route path="/politica-de-privacidade" element={<PrivacyPolicy />} />
+              <Route path="/termos-de-uso" element={<TermsOfService />} />
             </Routes>
           </main>
+          <Footer />
           <CookieBanner />
           <Toaster />
         </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function Footer() {
+  return (
+    <footer className="py-6 px-4 bg-slate-900 border-t border-white/10 text-center text-sm text-gray-400">
+      <div className="max-w-4xl mx-auto space-y-2">
+        <div className="space-x-2">
+          <Link to="/politica-de-privacidade" className="hover:underline text-gray-300">
+            Política de Privacidade
+          </Link>
+          <span>|</span>
+          <Link to="/termos-de-uso" className="hover:underline text-gray-300">
+            Termos de Uso
+          </Link>
+        </div>
+        <div className="text-gray-500">
+          © 2025 YD Software. Todos os direitos reservados. Sistema 100% local e seguro.
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add Footer component with privacy/terms links and copyright
- import Footer and add routes in App

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869def697788328a3211f505d77c8ef

## Resumo por Sourcery

Introduz um novo componente Footer com links para a política de privacidade e termos de serviço e o integra no layout da aplicação adicionando as rotas correspondentes.

Novas funcionalidades:
- Adiciona o componente Footer contendo links para as páginas de Política de Privacidade e Termos de Serviço e aviso de direitos de autor
- Regista rotas para PrivacyPolicy e TermsOfService na App e renderiza o Footer no layout

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new Footer component with privacy policy and terms of service links and integrate it into the app layout by adding corresponding routes.

New Features:
- Add Footer component containing links to the Privacy Policy and Terms of Service pages and copyright notice
- Register routes for PrivacyPolicy and TermsOfService in App and render the Footer in the layout

</details>