### PR TITLE
Add resume history and storage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import RegisterPage from '@/pages/RegisterPage';
 import PricingPage from '@/pages/PricingPage';
 import PrivacyPolicy from '@/pages/PrivacyPolicy';
 import TermsOfService from '@/pages/TermsOfService';
+import HistoryPage from '@/pages/HistoryPage';
 import { AuthProvider } from '@/contexts/SupabaseAuthContext';
 import Header from '@/components/Header';
 import CookieBanner from '@/components/CookieBanner';
@@ -25,6 +26,7 @@ function App() {
               <Route path="/curriculo-gerado" element={<ResultPage />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/cadastro" element={<RegisterPage />} />
+              <Route path="/historico" element={<HistoryPage />} />
               <Route path="/planos" element={<PricingPage />} />
               <Route path="/politica-de-privacidade" element={<PrivacyPolicy />} />
               <Route path="/termos-de-uso" element={<TermsOfService />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -42,6 +42,13 @@ function Header() {
                   </Button>
                 </li>
                 <li>
+                  <Link to="/historico">
+                    <Button variant="ghost" className="text-white hover:bg-white/10">
+                      Histórico
+                    </Button>
+                  </Link>
+                </li>
+                <li>
                   <Button onClick={handleLogout} variant="ghost" size="icon">
                     <LogOut className="w-5 h-5 text-red-400" />
                   </Button>

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/SupabaseAuthContext';
+import { supabase } from '@/lib/customSupabaseClient';
+import { ResumePreview } from '@/components/ResumePreview';
+import { Button } from '@/components/ui/button';
+
+function HistoryPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [curriculos, setCurriculos] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCurriculos = async () => {
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('curriculos')
+        .select('id, data, created_at')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        console.error('Erro ao buscar currículos:', error);
+      } else {
+        setCurriculos(data);
+      }
+      setLoading(false);
+    };
+    fetchCurriculos();
+  }, [user]);
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Helmet>
+          <title>Histórico de Currículos</title>
+        </Helmet>
+        <p className="text-gray-300">É necessário estar logado para visualizar o histórico.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>Histórico de Currículos</title>
+      </Helmet>
+      <div className="min-h-screen p-4 max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-white mb-6">Histórico de Currículos</h1>
+        {loading ? (
+          <p className="text-gray-300">Carregando...</p>
+        ) : curriculos.length === 0 ? (
+          <p className="text-gray-300">Nenhum currículo encontrado.</p>
+        ) : (
+          <div className="space-y-6">
+            {curriculos.map((item) => (
+              <div key={item.id} className="glass-effect p-4 rounded-xl">
+                <p className="text-gray-400 text-sm mb-4">
+                  {new Date(item.created_at).toLocaleString()}
+                </p>
+                <ResumePreview data={item.data} />
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="mt-8 text-center">
+          <Button onClick={() => navigate('/')}>Criar Novo Currículo</Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default HistoryPage;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -159,6 +159,15 @@ O currículo deve incluir as seguintes seções:
         generatedContent: generatedContent
       };
       localStorage.setItem('curriculoData', JSON.stringify(curriculoCompleto));
+
+      if (user) {
+        const { error } = await supabase
+          .from('curriculos')
+          .insert({ user_id: user.id, data: curriculoCompleto });
+        if (error) {
+          console.error('Erro ao salvar currículo:', error);
+        }
+      }
       toast({
         title: "Sucesso!",
         description: "Seu currículo foi gerado com sucesso!"


### PR DESCRIPTION
## Summary
- store generated resumes in Supabase when logged in
- add HistoryPage to list saved resumes
- link to new page in Header
- expose route `/historico` in router

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a9eb4828483288aed917d4b4bdb4f

## Resumo por Sourcery

Implementa a persistência de currículos e a navegação, salvando os currículos gerados no Supabase para usuários autenticados e adicionando uma página de histórico com navegação e gerenciamento de estado.

Novos Recursos:
- Persiste currículos gerados no Supabase para usuários autenticados
- Introduz uma `HistoryPage` na rota `/historico` para listar e visualizar currículos salvos
- Adiciona um link de navegação "Histórico" no cabeçalho

Melhorias:
- Exibe estados de carregamento e vazio na `HistoryPage`
- Mostra um prompt de não autenticado se um usuário não estiver logado

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement resume persistence and browsing by saving generated resumes to Supabase for logged-in users and adding a history page with navigation and state handling

New Features:
- Persist generated resumes in Supabase for authenticated users
- Introduce a HistoryPage at route `/historico` to list and preview saved resumes
- Add a “Histórico” navigation link in the header

Enhancements:
- Display loading and empty states on the HistoryPage
- Show an unauthenticated prompt if a user is not logged in

</details>