### PR TITLE
Add resume history and storage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import RegisterPage from '@/pages/RegisterPage';
 import PricingPage from '@/pages/PricingPage';
 import PrivacyPolicy from '@/pages/PrivacyPolicy';
 import TermsOfService from '@/pages/TermsOfService';
+import HistoryPage from '@/pages/HistoryPage';
 import { AuthProvider } from '@/contexts/SupabaseAuthContext';
 import Header from '@/components/Header';
 import CookieBanner from '@/components/CookieBanner';
@@ -25,6 +26,7 @@ function App() {
               <Route path="/curriculo-gerado" element={<ResultPage />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/cadastro" element={<RegisterPage />} />
+              <Route path="/historico" element={<HistoryPage />} />
               <Route path="/planos" element={<PricingPage />} />
               <Route path="/politica-de-privacidade" element={<PrivacyPolicy />} />
               <Route path="/termos-de-uso" element={<TermsOfService />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -42,6 +42,13 @@ function Header() {
                   </Button>
                 </li>
                 <li>
+                  <Link to="/historico">
+                    <Button variant="ghost" className="text-white hover:bg-white/10">
+                      Histórico
+                    </Button>
+                  </Link>
+                </li>
+                <li>
                   <Button onClick={handleLogout} variant="ghost" size="icon">
                     <LogOut className="w-5 h-5 text-red-400" />
                   </Button>

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/SupabaseAuthContext';
+import { supabase } from '@/lib/customSupabaseClient';
+import { ResumePreview } from '@/components/ResumePreview';
+import { Button } from '@/components/ui/button';
+
+function HistoryPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [curriculos, setCurriculos] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCurriculos = async () => {
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('curriculos')
+        .select('id, data, created_at')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        console.error('Erro ao buscar currículos:', error);
+      } else {
+        setCurriculos(data);
+      }
+      setLoading(false);
+    };
+    fetchCurriculos();
+  }, [user]);
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Helmet>
+          <title>Histórico de Currículos</title>
+        </Helmet>
+        <p className="text-gray-300">É necessário estar logado para visualizar o histórico.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>Histórico de Currículos</title>
+      </Helmet>
+      <div className="min-h-screen p-4 max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-white mb-6">Histórico de Currículos</h1>
+        {loading ? (
+          <p className="text-gray-300">Carregando...</p>
+        ) : curriculos.length === 0 ? (
+          <p className="text-gray-300">Nenhum currículo encontrado.</p>
+        ) : (
+          <div className="space-y-6">
+            {curriculos.map((item) => {
+              const resumeData =
+                typeof item.data === 'string' ? JSON.parse(item.data) : item.data;
+              return (
+                <div key={item.id} className="glass-effect p-4 rounded-xl">
+                  <p className="text-gray-400 text-sm mb-4">
+                    {new Date(item.created_at).toLocaleString()}
+                  </p>
+                  <ResumePreview data={resumeData} />
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <div className="mt-8 text-center">
+          <Button onClick={() => navigate('/')}>Criar Novo Currículo</Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default HistoryPage;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -159,6 +159,15 @@ O currículo deve incluir as seguintes seções:
         generatedContent: generatedContent
       };
       localStorage.setItem('curriculoData', JSON.stringify(curriculoCompleto));
+
+      if (user) {
+        const { error } = await supabase
+          .from('curriculos')
+          .insert({ user_id: user.id, data: JSON.stringify(curriculoCompleto) });
+        if (error) {
+          console.error('Erro ao salvar currículo:', error);
+        }
+      }
       toast({
         title: "Sucesso!",
         description: "Seu currículo foi gerado com sucesso!"


### PR DESCRIPTION
## Summary
- store generated resumes in Supabase when logged in
- add HistoryPage to list saved resumes
- link to new page in Header
- expose route `/historico` in router
- fix saved resume insertion and parse history entries

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a9eb4828483288aed917d4b4bdb4f