### PR TITLE
Fix CV history saving

### DIFF
--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -27,7 +27,12 @@ function HistoryPage() {
       if (error) {
         console.error('Erro ao buscar currículos:', error);
       } else {
-        setCurriculos(data);
+        // Parse stored JSON string if necessary
+        const parsed = data.map(item => ({
+          ...item,
+          data: typeof item.data === 'string' ? JSON.parse(item.data) : item.data
+        }));
+        setCurriculos(parsed);
       }
       setLoading(false);
     };

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -163,7 +163,8 @@ O currículo deve incluir as seguintes seções:
       if (user) {
         const { error } = await supabase
           .from('curriculos')
-          .insert({ user_id: user.id, data: curriculoCompleto });
+          // Store as string to avoid JSON column issues
+          .insert({ user_id: user.id, data: JSON.stringify(curriculoCompleto) });
         if (error) {
           console.error('Erro ao salvar currículo:', error);
         }


### PR DESCRIPTION
## Summary
- store generated resume data in Supabase as JSON string
- parse resume JSON when loading from history

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686aa6ef01148328acefa3e0c973bcbf