### PR TITLE
Fix resume save data

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -163,8 +163,7 @@ O currículo deve incluir as seguintes seções:
       if (user) {
         const { error } = await supabase
           .from('curriculos')
-          // Store as string to avoid JSON column issues
-          .insert({ user_id: user.id, data: JSON.stringify(curriculoCompleto) });
+          .insert({ user_id: user.id, data: curriculoCompleto });
         if (error) {
           console.error('Erro ao salvar currículo:', error);
         }


### PR DESCRIPTION
## Summary
- ensure resume data is stored in Supabase as JSON rather than string

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686aa95c692083289f1b8ddaacf46603

## Resumo por Sourcery

Correções de Bugs:
- Remover `JSON.stringify` e inserir os dados do currículo diretamente para corrigir problemas de inserção na coluna JSON

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove JSON.stringify and insert the resume data directly to fix JSON column insertion issues

</details>