### PR TITLE
Add Supabase schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,22 @@ VITE_SUPABASE_ANON_KEY=
 ```
 
 Insira os valores adequados para cada chave antes de iniciar o projeto.
+
+## Supabase
+
+O projeto utiliza o [Supabase](https://supabase.com/) para autenticação e
+armazenamento dos currículos gerados. No diretório `supabase/` há um arquivo
+`schema.sql` contendo a estrutura das tabelas usadas pela aplicação. Para
+configurar o banco de dados, faça o upload desse script no painel do Supabase
+ou execute-o usando a CLI:
+
+```bash
+supabase db push supabase/schema.sql
+```
+
+As tabelas criadas são:
+
+* **profiles** – estende `auth.users` com informações de assinatura e controle
+  de geração.
+* **curriculos** – armazena cada currículo criado e está relacionado ao usuário
+  que o gerou.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,21 @@
+-- Database schema for microsaas-curriculo
+-- Create tables used by the application
+
+-- Table to store additional user profile info
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  is_subscriber boolean not null default false,
+  generation_count integer not null default 0,
+  last_generation_date timestamp with time zone
+);
+
+-- Table to store generated resumes
+create table if not exists public.curriculos (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  data jsonb not null,
+  created_at timestamp with time zone not null default now()
+);
+
+-- Index to speed up lookups by user
+create index if not exists curriculos_user_id_idx on public.curriculos(user_id);


### PR DESCRIPTION
## Summary
- create `schema.sql` with tables for profiles and currículos
- document how to apply the schema in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686aacd0b04c8328a07f2cac0372873d

## Resumo por Sourcery

Adiciona o esquema do banco de dados Supabase e instruções de uso

Novos Recursos:
- Introduz o arquivo `schema.sql` definindo as tabelas `profiles` e `curriculos` com relacionamentos e índice

Documentação:
- Documenta a configuração do Supabase e os passos de implantação do esquema no README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Supabase database schema and usage instructions

New Features:
- Introduce `schema.sql` file defining `profiles` and `curriculos` tables with relationships and index

Documentation:
- Document Supabase setup and schema deployment steps in README

</details>