### PR TITLE
Add Supabase DB init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ O projeto utiliza o Supabase para autenticação e armazenamento dos currículos
 supabase db push supabase/schema.sql
 ```
 
+Se preferir, execute o script abaixo que realiza o mesmo comando automaticamente
+(é necessário ter o Supabase CLI instalado):
+
+```bash
+npm run setup:db
+```
+
 As tabelas criadas são:
 
 - **profiles** – complementa `auth.users` com dados de assinatura e controle de geração.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "node tools/generate-llms.js || true && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "setup:db": "bash ./scripts/setup-db.sh"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.0.5",

--- a/scripts/setup-db.sh
+++ b/scripts/setup-db.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Initialize Supabase tables using the schema.sql file
+
+set -e
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "Supabase CLI not found. Please install it: https://supabase.com/docs/guides/cli" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+supabase db push "$ROOT_DIR/supabase/schema.sql"


### PR DESCRIPTION
## Summary
- add `scripts/setup-db.sh` to create missing Supabase tables
- expose npm script `setup:db`
- document the new script in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ba6b75e088328992f11235da61e5f