### PR TITLE
Add account management page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import PricingPage from '@/pages/PricingPage';
 import PrivacyPolicy from '@/pages/PrivacyPolicy';
 import TermsOfService from '@/pages/TermsOfService';
 import HistoryPage from '@/pages/HistoryPage';
+import AccountPage from '@/pages/AccountPage';
 import { AuthProvider } from '@/contexts/SupabaseAuthContext';
 import Header from '@/components/Header';
 import CookieBanner from '@/components/CookieBanner';
@@ -27,6 +28,7 @@ function App() {
               <Route path="/login" element={<LoginPage />} />
               <Route path="/cadastro" element={<RegisterPage />} />
               <Route path="/historico" element={<HistoryPage />} />
+              <Route path="/conta" element={<AccountPage />} />
               <Route path="/planos" element={<PricingPage />} />
               <Route path="/politica-de-privacidade" element={<PrivacyPolicy />} />
               <Route path="/termos-de-uso" element={<TermsOfService />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -49,6 +49,13 @@ function Header() {
                   </Link>
                 </li>
                 <li>
+                  <Link to="/conta">
+                    <Button variant="ghost" className="text-white hover:bg-white/10">
+                      Conta
+                    </Button>
+                  </Link>
+                </li>
+                <li>
                   <Button onClick={handleLogout} variant="ghost" size="icon">
                     <LogOut className="w-5 h-5 text-red-400" />
                   </Button>

--- a/src/contexts/SupabaseAuthContext.jsx
+++ b/src/contexts/SupabaseAuthContext.jsx
@@ -83,6 +83,43 @@ export const AuthProvider = ({ children }) => {
     return { error };
   }, [toast]);
 
+  const updatePassword = useCallback(
+    async (currentPassword, newPassword) => {
+      if (!user) {
+        return { error: new Error('Usuário não autenticado') };
+      }
+
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email: user.email,
+        password: currentPassword,
+      });
+
+      if (signInError) {
+        toast({
+          variant: 'destructive',
+          title: 'Senha atual incorreta',
+          description: signInError.message || 'Credenciais inválidas',
+        });
+        return { error: signInError };
+      }
+
+      const { error } = await supabase.auth.updateUser({ password: newPassword });
+
+      if (error) {
+        toast({
+          variant: 'destructive',
+          title: 'Erro ao atualizar senha',
+          description: error.message || 'Algo deu errado',
+        });
+      } else {
+        toast({ title: 'Senha alterada com sucesso' });
+      }
+
+      return { error };
+    },
+    [toast, user]
+  );
+
   const value = useMemo(() => ({
     user,
     session,
@@ -90,7 +127,8 @@ export const AuthProvider = ({ children }) => {
     signUp,
     signIn,
     signOut,
-  }), [user, session, loading, signUp, signIn, signOut]);
+    updatePassword,
+  }), [user, session, loading, signUp, signIn, signOut, updatePassword]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/contexts/SupabaseAuthContext';
+import { useToast } from '@/components/ui/use-toast';
+
+function AccountPage() {
+  const { user, updatePassword } = useAuth();
+  const { toast } = useToast();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <p className="text-gray-300">É necessário estar logado para acessar esta página.</p>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      toast({
+        variant: 'destructive',
+        title: 'As novas senhas não coincidem',
+      });
+      return;
+    }
+    setLoading(true);
+    const { error } = await updatePassword(currentPassword, newPassword);
+    if (!error) {
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title>Gerenciar Conta</title>
+      </Helmet>
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <div className="w-full max-w-md glass-effect rounded-2xl p-8">
+          <h1 className="text-2xl font-bold text-white mb-6">Alterar Senha</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="current" className="text-white font-medium">Senha Atual</Label>
+              <Input
+                id="current"
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                required
+                className="bg-white/5 border-white/20 text-white placeholder-white/60"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="new" className="text-white font-medium">Nova Senha</Label>
+              <Input
+                id="new"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                required
+                className="bg-white/5 border-white/20 text-white placeholder-white/60"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirm" className="text-white font-medium">Confirmar Nova Senha</Label>
+              <Input
+                id="confirm"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className="bg-white/5 border-white/20 text-white placeholder-white/60"
+              />
+            </div>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white py-3"
+            >
+              {loading ? 'Salvando...' : 'Alterar Senha'}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default AccountPage;


### PR DESCRIPTION
## Summary
- add account page to change the user password
- update SupabaseAuthContext with `updatePassword`
- register new route and menu entry

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711370f8f0832893276534ff784eca